### PR TITLE
Resolve VSCode keybinding conflicts from 2TK1340241

### DIFF
--- a/KEYBINDINGS_CONFLICT_2TK1340241.md
+++ b/KEYBINDINGS_CONFLICT_2TK1340241.md
@@ -1,0 +1,32 @@
+# Keyboard Shortcuts Conflict Resolution
+
+**Machine:** 2TK1340241
+**Date:** Thu Jul 24 17:22:52 MDT 2025
+**Branch:** keybindings-sync-2TK1340241-20250724-172251
+
+## Conflicts Detected
+
+CONFLICT: Key "ctrl+w" - Local: workbench.action.terminal.killEditor vs Repo: workbench.action.terminal.kill
+
+## Files
+
+- `keybindings-2TK1340241.json` - Local keybindings from 2TK1340241
+- `vscode-keybindings.json` - Canonical/repository keybindings
+
+## Resolution Steps
+
+1. Review the conflicts above
+2. Manually merge the files, choosing the preferred keybinding for each conflict
+3. Update `vscode-keybindings.json` with the resolved bindings
+4. Delete this conflict file and the machine-specific file
+5. Commit and create a pull request
+
+## Auto-generated Merge Command
+
+```bash
+# After resolving conflicts manually, run:
+git add vscode-keybindings.json
+git commit -m "Resolve keybinding conflicts from 2TK1340241"
+git push -u origin keybindings-sync-2TK1340241-20250724-172251
+gh pr create --title "Resolve VSCode keybinding conflicts from 2TK1340241" --body "Auto-generated PR to resolve keyboard shortcut conflicts"
+```

--- a/keybindings-2TK1340241.json
+++ b/keybindings-2TK1340241.json
@@ -1,0 +1,12 @@
+[
+  {
+    "command": "workbench.action.toggleMaximizedPanel",
+    "key": "ctrl+alt+`",
+    "when": "panelAlignment == 'center' || panelPosition != 'bottom' && panelPosition != 'top'"
+  },
+  {
+    "key": "ctrl+w",
+    "command": "workbench.action.terminal.killEditor",
+    "when": "terminalFocus && terminalProcessSupported && resourceScheme == 'vscode-terminal'"
+  }
+]


### PR DESCRIPTION
Auto-generated PR to resolve keyboard shortcut conflicts detected on 2TK1340241. See KEYBINDINGS_CONFLICT_2TK1340241.md for details.